### PR TITLE
updated-readme-commands-to-match-the-apps-commonds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ These commands are used to generate the code necessary for running a server.
 
 | command | description |
 | ------- | ----------- |
-|``` mevn-cli create:routes ``` | To create the Routes-File(API) |
-|``` mevn-cli create:models ``` | To create the Models-File(SCHEMA) |
-|``` mevn-cli create:controllers``` |  To create the Controllers-File |
+|``` mevn-cli create:route ``` | To create the Routes-File(API) |
+|``` mevn-cli create:model ``` | To create the Models-File(SCHEMA) |
+|``` mevn-cli create:controller``` |  To create the Controllers-File |
 | ```mevn-cli create:config ``` | To create the Config-File |
 
 


### PR DESCRIPTION
I noticed while working that the Readme commands are shown as follows
```create:controllers```
```create:models```
```create:routes```

these don't match up with those defined within the app its self