### PR TITLE
Fix new project not created if a non-empty folder with the same name as boilerplate repo exists.

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -6,7 +6,6 @@ const shell = require('shelljs');
 const inquirer = require('inquirer');
 const elegantSpinner = require('elegant-spinner');
 const logUpdate = require('log-update');
-const os = require('os');
 const Table = require('cli-table');
 const validate  = require('validate-npm-package-name');
 const { showBanner } = require('../external/banner');
@@ -67,7 +66,7 @@ let fetchTemplate = (template) => {
   if (template !== 'basic') {
     templateDir = `mevn-${template}-boilerplate`;
   }
-  shell.exec(boilerplate[template], {silent: true}, {async: true});
+  shell.exec(`${boilerplate[template]} ${projectName}`, {silent: true}, {async: true});
 
   let fetchSpinner = setInterval(() => {
     logUpdate('Fetching the boilerplate ' + chalk.cyan.bold.dim(frame()));
@@ -80,9 +79,6 @@ let fetchTemplate = (template) => {
     showTables();
 
   }, 5000);
-
-  let renameCmd = os.type() === 'Windows_NT' ? 'ren' : 'mv';
-  shell.exec(`${renameCmd} ${templateDir} ${projectName}`);
 
   fs.writeFileSync(`./${projectName}/mevn.json`, projectConfig.join('\n').toString());
 


### PR DESCRIPTION
Hi,
I came across this issue today. While creating a new project, if a non-empty folder with the same name as the base boilerplate repository name (mevn-boilerplate/mevn-pwa-boilerplate..) exists in the same location, then the new project is not created and the folder with boilerplate name is renamed to the new project name.

This is happening because we are first cloning the boilerplate repo and then renaming it. So, while cloning, it detects that a non-empty folder with the same name already exists and it stops cloning. The renaming is then done on the existing folder.

## Fix
This can be fixed by cloning the boilerplate repo directly with the new project name instead of the repo name. This way we eliminate the need for renaming as well.

This can be done by passing the project name as an additional option to git clone command.
Eg: `git clone url project_name`