### PR TITLE
Fix error while deleting .git directory on Windows

### DIFF
--- a/src/commands/basic/init.js
+++ b/src/commands/basic/init.js
@@ -3,6 +3,7 @@
 import chalk from 'chalk';
 import execa from 'execa';
 import fs from 'fs';
+import path from 'path';
 import inquirer from 'inquirer';
 import Table from 'cli-table3';
 import validate from 'validate-npm-package-name';
@@ -72,8 +73,8 @@ let showTables = () => {
     `${chalk.yellow.bold('\n Warning: ')} Do not delete the mevn.json file`,
   );
 
-  let removeCmd = process.platform === 'win32' ? 'del' : 'rm -rf';
-  require('child_process').execSync(`${removeCmd} ${projectName}/.git`);
+  let removeCmd = process.platform === 'win32' ? 'rmdir /s /q' : 'rm -rf';
+  execa.shellSync(`${removeCmd} ${path.join(projectName, '.git')}`);
   makeInitialCommit();
 };
 


### PR DESCRIPTION
There was an error thrown while deleting the `.git` directory on Windows.  

The main reason was due to the path. Windows uses `\` in it's path and Unix uses `/`. Hence, have to use the `path` module to dynamically generate the path based on OS.  

Secondly, we would like to delete all the contents of `.git ` directory. Hence, have to use `rmdir` command with options in place of `del` command.