### PR TITLE
replacing sync variants of fs.readFileSync & fs.writeFileSync with async variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10831,7 +10831,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10852,12 +10853,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10870,17 +10873,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10995,7 +11001,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11007,6 +11014,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11021,6 +11029,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11131,7 +11140,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11143,6 +11153,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11263,6 +11274,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11282,6 +11294,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11310,7 +11323,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
@@ -14072,7 +14086,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14093,12 +14108,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14113,17 +14130,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14240,7 +14260,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14252,6 +14273,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14266,6 +14288,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14273,12 +14296,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14297,6 +14322,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14377,7 +14403,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14389,6 +14416,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14474,7 +14502,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14510,6 +14539,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14529,6 +14559,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14572,12 +14603,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -17648,6 +17681,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -17657,7 +17691,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/commands/basic/init.js
+++ b/src/commands/basic/init.js
@@ -8,7 +8,7 @@ import inquirer from 'inquirer';
 import showBanner from 'node-banner';
 import validate from 'validate-npm-package-name';
 
-import { copyDirSync } from '../../utils/fs';
+import { copyDirSync, readFileAsync, writeFileAsync } from '../../utils/fs';
 import { isWin } from '../../utils/constants';
 import {
   directoryExistsInPath,
@@ -121,7 +121,7 @@ const fetchTemplate = async templateBranch => {
 
   fetchSpinner.stop();
 
-  fs.writeFileSync(
+  await writeFileAsync(
     `./${projectName}/mevn.json`,
     projectConfig.join('\n').toString(),
   );
@@ -138,13 +138,12 @@ const fetchTemplate = async templateBranch => {
 
     // Write to mevn.json in order to keep track while installing dependencies
     if (requirePwaSupport) {
-      let configFile = JSON.parse(
-        fs.readFileSync(`./${projectName}/mevn.json`).toString(),
-      );
-      configFile['isPwa'] = true;
+      let configFile = await readFileAsync(`./${projectName}/mevn.json`);
+      let configFileContent = JSON.parse(configFile.toString());
+      configFileContent['isPwa'] = true;
       fs.writeFileSync(
         `./${projectName}/mevn.json`,
-        JSON.stringify(configFile),
+        JSON.stringify(configFileContent),
       );
     }
 

--- a/src/commands/basic/init.js
+++ b/src/commands/basic/init.js
@@ -8,7 +8,7 @@ import inquirer from 'inquirer';
 import showBanner from 'node-banner';
 import validate from 'validate-npm-package-name';
 
-import copyDirSync from '../../utils/fs';
+import { copyDirSync } from '../../utils/fs';
 import { isWin } from '../../utils/constants';
 import {
   directoryExistsInPath,

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -1,5 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+import { promisify } from 'util';
+
+/**
+ *  Convert into async variants
+ */
+
+const readFileAsync = promisify(fs.readFile);
+const writeFileAsync = promisify(fs.writeFile);
 
 /**
  * Copy files
@@ -47,4 +55,4 @@ const copyDirSync = (source, target) => {
   }
 };
 
-module.exports = copyDirSync;
+module.exports = { copyDirSync, readFileAsync, writeFileAsync };


### PR DESCRIPTION
## Description
As blocking the main thread while execution is bad for the performance, it is better to `promisify` some of the synchronous actions and then `await` for it.
Also, using `fs.readFileSync` is not performant compared to `fs.readFile`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

