### PR TITLE
feat: use the inhouse solution to open up default browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "commander": "^2.16.0",
     "didyoumean": "^1.2.1",
     "envinfo": "^7.3.1",
-    "execa": "^1.0.0",
+    "execa": "^4.0.0",
     "inquirer": "^6.0.0",
     "node-banner": "^1.3.2",
     "open": "^6.3.0",

--- a/src/commands/basic/docker.js
+++ b/src/commands/basic/docker.js
@@ -22,9 +22,9 @@ const dockerize = async () => {
   try {
     // Requires administrative (super-user) privilege
     // Sets up the environment by pulling required images as in the config file
-    const { stdout } = await execa.shell(
+    const { stdout } = await execa.command(
       `${isWin ? '' : 'sudo'} docker-compose up`,
-      { stdio: 'inherit' },
+      { stdio: 'inherit', shell: true },
     );
 
     // Log the results to stdout

--- a/src/commands/deploy/surge.js
+++ b/src/commands/deploy/surge.js
@@ -15,7 +15,7 @@ import Spinner from '../../utils/spinner';
 
 const exec = async (cmd, spinner, successMsg) => {
   try {
-    await execa.shell(cmd);
+    await execa.command(cmd, { shell: true });
     spinner.succeed(successMsg);
   } catch (err) {
     spinner.fail('Something went wrong');

--- a/src/commands/serve/launch.js
+++ b/src/commands/serve/launch.js
@@ -2,7 +2,6 @@
 
 import execa from 'execa';
 import fs from 'fs';
-import open from 'open';
 
 import Spinner from '../../utils/spinner';
 
@@ -82,7 +81,7 @@ const serveProject = async (projectTemplate, templateDir) => {
   let port;
 
   if (templateDir === 'client') {
-    port = projectTemplate === 'Nuxt-js' ? '3000' : '8080';
+    port = projectTemplate === 'Nuxt-js' ? '3000' : '3002';
   } else {
     port = projectTemplate === 'graphql' ? '9000/graphql' : '9000/api';
   }
@@ -111,7 +110,7 @@ const serveProject = async (projectTemplate, templateDir) => {
   );
 
   launchSpinner.start();
-  Promise.all([execa.shell('npm run serve'), open(`${rootPath}:${port}`)]);
+  execa.command(`npm run serve -- --port ${port} --open`);
   launchSpinner.info(`Available on ${rootPath}:${port}`);
 };
 

--- a/src/commands/serve/setup.js
+++ b/src/commands/serve/setup.js
@@ -38,7 +38,7 @@ const setupProject = async () => {
     templateDir = 'client';
   }
 
-  // Navigate to the respectice directory
+  // Navigate to the respective directory
   process.chdir(templateDir);
 
   // Proceed with further installation

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -19,7 +19,7 @@ const spinner = new Spinner();
 
 const dependencyIsInstalled = async dependency => {
   try {
-    await execa.shell(dependency);
+    await execa.command(dependency, { shell: true });
     return true;
   } catch (err) {
     return false;
@@ -88,8 +88,8 @@ const validateInput = componentName => {
 const exec = async cmd => {
   return new Promise(async () => {
     try {
-      await execa.shell('sudo apt update', { stdio: 'inherit' });
-      await execa.shell(cmd), { stdio: 'inherit' };
+      await execa.command('sudo apt update', { stdio: 'inherit', shell: true });
+      await execa.command(cmd, { stdio: 'inherit', shell: true });
       spinner.succeed(`You're good to go`);
     } catch (err) {
       spinner.fail('Something went wrong');


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Use vue-cli-service's --open. 
Pass port from launch.js . 
Use port 3002. 
Update execa to latest. 
Convert .shell() to option {shell:true}

**Did you add tests for your changes?**
Would love some guidance with this.

**If relevant, did you update the documentation?**
Doesn't change external api

**Summary**

Fixes #164 and #142 

**Does this PR introduce a breaking change?**
No
**Other information**
