### PR TITLE
fix: regression with Nuxt.js template while onboarding the PWA module

### DIFF
--- a/src/commands/basic/init.js
+++ b/src/commands/basic/init.js
@@ -139,7 +139,10 @@ const fetchTemplate = async (templateBranch) => {
     // Write to .mevnrc in order to keep track while installing dependencies
     if (requirePwaSupport) {
       let configFile = JSON.parse(fs.readFileSync(`./${projectName}/.mevnrc`));
-      configFile['isPwa'] = true;
+      configFile = Object.assign(configFile, {
+        isPwa: true,
+        isPwaConfigured: false,
+      });
       fs.writeFileSync(
         `./${projectName}/.mevnrc`,
         JSON.stringify(configFile, null, 2),

--- a/src/commands/basic/init.js
+++ b/src/commands/basic/init.js
@@ -139,10 +139,7 @@ const fetchTemplate = async (templateBranch) => {
     // Write to .mevnrc in order to keep track while installing dependencies
     if (requirePwaSupport) {
       let configFile = JSON.parse(fs.readFileSync(`./${projectName}/.mevnrc`));
-      configFile = Object.assign(configFile, {
-        isPwa: true,
-        isPwaConfigured: false,
-      });
+      configFile = { ...configFile, isPwa: true, isPwaConfigured: false };
       fs.writeFileSync(
         `./${projectName}/.mevnrc`,
         JSON.stringify(configFile, null, 2),

--- a/src/commands/serve/launch.js
+++ b/src/commands/serve/launch.js
@@ -20,9 +20,9 @@ const configurePwaSupport = async () => {
   if (configFile['isPwa'] && !configFile['isPwaConfigured']) {
     // Install the @nuxtjs/pwa package.
     try {
-      await execa('npm', ['install', '@nuxtjs/pwa']);
+      await execa('npm', ['install', '--save', '@nuxtjs/pwa']);
     } catch (err) {
-      console.log(err);
+      console.error(err);
       process.exit(1);
     }
 
@@ -61,10 +61,8 @@ const configurePwaSupport = async () => {
     // Hop back to the root directory
     process.chdir('../');
 
-    // set the isPwaConfigured flag in the config file
-    configFile = Object.assign(configFile, {
-      isPwaConfigured: true,
-    });
+    // set isPwaConfigured key in the config file to true
+    configFile.isPwaConfigured = true;
 
     fs.writeFileSync(`./.mevnrc`, JSON.stringify(configFile, null, 2));
   }

--- a/src/commands/serve/launch.js
+++ b/src/commands/serve/launch.js
@@ -17,7 +17,7 @@ const configurePwaSupport = async () => {
 
   let configFile = JSON.parse(fs.readFileSync('./.mevnrc'));
 
-  if (configFile['isPwa']) {
+  if (configFile['isPwa'] && !configFile['isPwaConfigured']) {
     // Install the @nuxtjs/pwa package.
     try {
       await execa('npm', ['install', '@nuxtjs/pwa']);
@@ -60,6 +60,13 @@ const configurePwaSupport = async () => {
 
     // Hop back to the root directory
     process.chdir('../');
+
+    // set the isPwaConfigured flag in the config file
+    configFile = Object.assign(configFile, {
+      isPwaConfigured: true,
+    });
+
+    fs.writeFileSync(`./.mevnrc`, JSON.stringify(configFile, null, 2));
   }
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #172 by introducing a `isPwaConfigured` flag in the `.mevnrc` to prevent from reconfiguring the app for PWA in each launch.

**Summary**
Refer #172 