### PR TITLE
feat: add graphql-depth-limit to prevent dos attacks

### DIFF
--- a/src/templates/server/GraphQL/package.json
+++ b/src/templates/server/GraphQL/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.4",
     "express-graphql": "^0.8.0",
-    "graphql": "^14.0.2"
+    "graphql": "^14.0.2",
+    "graphql-depth-limit": "^1.1.0"
   },
   "devDependencies": {
     "nodemon": "^1.18.6",

--- a/src/templates/server/GraphQL/server.js
+++ b/src/templates/server/GraphQL/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const graphQLHttp = require('express-graphql');
 const schema = require('./graphql/schema');
+const depthLimit = require('graphql-depth-limit');
 const cors = require('cors');
 const app = express();
 
@@ -13,6 +14,7 @@ app.use(
   graphQLHttp({
     schema,
     graphiql: true,
+    validationRules: [depthLimit(10)],    
   }),
 );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR adds graphql-depth-limit as a new dependency to the GraphQL template to prevent Denial Of Service through nested queries.

**Did you add tests for your changes?**

NA

**If relevant, did you update the documentation?**

NA

**Summary**

Due to a circular relationship in the GraphQL schema, it's possible to create a query that becomes exponentially more complex with almost no effort that can ultimately lead to Denial of Service. This PR prevents those types of attacks my setting depth limit to be 10.

**Does this PR introduce a breaking change?**

No

**Other information**
* https://jauntyjake.medium.com/protecting-against-deeply-nested-graphql-queries-9f6db003002e
* https://www.apollographql.com/blog/graphql/security/securing-your-graphql-api-from-malicious-queries/
* https://gitlab.com/gitlab-org/gitlab/-/issues/30096