### PR TITLE
fix(add): prevent errors when supplying dependencies for `Nuxt.js` template

### DIFF
--- a/src/commands/add/index.js
+++ b/src/commands/add/index.js
@@ -34,11 +34,13 @@ export default async (deps, { dev }) => {
 
   const { isConfigured, template, packageManager } = fetchProjectConfig();
 
+  const templateIsNuxt = template === 'Nuxt.js';
+
   // Do not proceed if the deps were not supplied
+  // Nuxt.js template is the only exception
   if (
     !deps.length &&
-    (templateDir === 'server' ||
-      (templateDir === 'client' && template !== 'Nuxt.js'))
+    (templateDir === 'server' || (templateDir === 'client' && !templateIsNuxt))
   ) {
     logger.warn(' Please specify the dependencies to install');
     process.exit(1);
@@ -61,11 +63,16 @@ export default async (deps, { dev }) => {
     );
   }
 
-  // No need for further config
-  if (dev) return;
+  // Further confifuration is not required for the following
+  // 1. Dev dependencies
+  // 2. Dependencies installed in the server directory
+  // Nuxt.js template with dependencies specified as arguments
+  if (dev || templateDir === 'server' || (templateIsNuxt && deps.length)) {
+    return;
+  }
 
   // Nuxt.js modules are installed via multiselect prompt
-  if (template === 'Nuxt.js' && !deps.length) {
+  if (templateIsNuxt) {
     // Holds reference to the project specific config (.mevnrc)
     const projectConfig = fetchProjectConfig();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bug fix

**Did you add tests for your changes?**

The existing test suite accounts for it.

**If relevant, did you update the documentation?**

N/A

**Summary**

Fixes #247

This PR fixes the issue about specifying dependencies to be installed with the `add` command fails for the `Nuxt.js` template irrespective of the directory `client/server`. The proposed fix skips from performing further configuration if the template chosen is `Nuxt.js` or the directory is `server` regardless of the template. All other starter templates have the `client/src/main.js` as a valid path, which wasn't the case with `Nuxt.js`. For the server directory, this isn't required since all configuration updates happen for dependencies relating to the `client` (`vuex`, `vuetify`, Nuxt modules, etc).

**Does this PR introduce a breaking change?**

No

**Other information**

N/A